### PR TITLE
Use LOCALAPPDATA for cache when on Windows

### DIFF
--- a/lib/batali/command.rb
+++ b/lib/batali/command.rb
@@ -58,7 +58,7 @@ module Batali
     # @return [String] correct user home location for platform
     def user_home
       if RUBY_PLATFORM =~ /mswin|mingw|windows/
-        ENV['LOCALAPPDATA']
+        ENV.fetch('LOCALAPPDATA', Dir.home)
       else
         Dir.home
       end

--- a/lib/batali/command.rb
+++ b/lib/batali/command.rb
@@ -55,10 +55,19 @@ module Batali
       end
     end
 
+    # @return [String] correct user home location for platform
+    def user_home
+      if RUBY_PLATFORM =~ /mswin|mingw|windows/
+        ENV['LOCALAPPDATA']
+      else
+        Dir.home
+      end
+    end
+
     # @return [String] path to local cache
     def cache_directory(*args)
       memoize(['cache_directory', *args].join('_')) do
-        directory = config.fetch(:cache_directory, File.join(Dir.home, '.batali', 'cache'))
+        directory = config.fetch(:cache_directory, File.join(user_home, '.batali', 'cache'))
         ui.debug "Cache directory to persist cookbooks: #{directory}"
         unless(args.empty?)
           directory = File.join(directory, *args.map(&:to_s))


### PR DESCRIPTION
It is common to use LOCALAPPDATA for this type of thing on windows and
this avoids cases where user HOME is unset. When HOME is unset on
windows it is resolved to HOMEDRIVE\HOMEPATH, which can be a network
path and results in terrible performance for batali.

Sorry, no tests. Wasn't sure what you'd want in that regard in the command_spec.rb.
