### PR TITLE
Add command line flag for unattended cache scrub, fixes #94

### DIFF
--- a/bin/batali
+++ b/bin/batali
@@ -15,6 +15,7 @@ Bogo::Cli::Setup.define do
     on :V, :verbose, 'Enable verbose output'
     on :D, :debug, 'Enable debug mode'
     on :f, :file=, 'Path to Batali file'
+    on :y, :yes, 'Answer yes to interactive prompts'
   end
 
   command 'display' do

--- a/lib/batali/command/cache.rb
+++ b/lib/batali/command/cache.rb
@@ -17,7 +17,7 @@ module Batali
 
       # Remove all contents from local cache
       def scrub!
-        ui.confirm "Remove all contents from local cache (#{cache_directory})"
+        ui.confirm "Remove all contents from local cache (#{cache_directory})" unless opts[:yes]
         run_action 'Scrubbing local cache' do
           FileUtils.rm_rf(cache_directory)
           nil


### PR DESCRIPTION
This allows the `cache -s` command to be run without user interaction