### PR TITLE
Fix deprecation warnings for ruby 2.4

### DIFF
--- a/lib/batali/b_file.rb
+++ b/lib/batali/b_file.rb
@@ -57,7 +57,16 @@ module Batali
     end
 
     ::Object.constants.each do |const_name|
-      next if const_name == :Config || const_name == :TimeoutError
+      deprecated_constants = [
+        :Config,
+        :TimeoutError,
+        :Fixnum,
+        :Bignum,
+        :NIL,
+        :TRUE,
+        :FALSE
+      ]
+      next if deprecated_constants.include?(const_name)
       const_set(const_name, ::Object.const_get(const_name))
     end
 
@@ -66,7 +75,16 @@ module Batali
       instance_exec do
         class << self
           ::Object.constants.each do |const_name|
-            next if const_name == :Config || const_name == :TimeoutError
+            deprecated_constants = [
+              :Config,
+              :TimeoutError,
+              :Fixnum,
+              :Bignum,
+              :NIL,
+              :TRUE,
+              :FALSE
+            ]
+            next if deprecated_constants.include?(const_name)
             const_set(const_name, ::Object.const_get(const_name))
           end
         end


### PR DESCRIPTION
simple and naive fix to remove warnings

ruby issues:
- https://bugs.ruby-lang.org/issues/11547
- https://bugs.ruby-lang.org/issues/12005